### PR TITLE
Create draft codemeta.json file

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -1,0 +1,36 @@
+{
+    "@context": "https://w3id.org/codemeta/3.0",
+    "applicationCategory": "SoftwareSourceCode",
+    "author": [
+        {
+            "name": "King's Digital Lab",
+            "@id": "https://github.com/kingsdigitallab",
+            "@type": "Organization"
+        }
+    ],
+    "codeRepository": "https://github.com/kingsdigitallab/framesense",
+    "dateCreated": "2025-06-17",
+    "description": "A modular command-line tool to process video collections.",
+    "identifier": "framesense",
+    "keywords": [
+        "command-line-tool",
+        "reusable",
+        "video-processing"
+    ],
+    "license": "https://spdx.org/licenses/MIT",
+    "name": "framesense",
+    "programmingLanguage": "Python",
+    "softwareRequirements": [
+        {
+            "name": "python-dotenv",
+            "version": "==1.1.0"
+        },
+        {
+            "name": "spython",
+            "version": "==0.3.14"
+        },
+        "* python 3.10+ * Docker or Singularity"
+    ],
+    "issueTracker": "https://github.com/kingsdigitallab/framesense/issues",
+    "@type": "SoftwareSourceCode"
+}


### PR DESCRIPTION
Further to the email sent to Dr Daniel Chávez last week on behalf of the [CCP-AHC](https://www.ccpahc.ac.uk/) project, I'm opening this pull request to contribute a `codemeta.json` file.
Codemeta is a schema designed to enable software citation by standardising metadata about the project. It is defined and documented at https://codemeta.github.io/.
This pull request creates a file to that standard for this repository, starting from the details automatically filled out by https://autocodemeta.linkeddata.es/ and editing to fill in the gaps the generator is unable to automatically scrape with details manually extracted from the repository and linked pages.

Please do tell me in the discussion where details are inaccurate so that we can bring the codemeta.json file up to date with the project.